### PR TITLE
support log15 levels

### DIFF
--- a/lib/fluent/plugin/filter_kubernetes_log_level.rb
+++ b/lib/fluent/plugin/filter_kubernetes_log_level.rb
@@ -37,15 +37,15 @@ module Fluent
         case level.downcase
         when 'trace', 'verbose'
           10
-        when 'debug'
+        when 'debug', 'dbug'
           20
         when 'info', 'information'
           30
         when 'warning', 'warn'
           40
-        when 'error'
+        when 'error', 'eror'
           50
-        when 'fatal'
+        when 'fatal', 'crit'
           60
         else
           level.to_i


### PR DESCRIPTION
Grafana using log15 levels - you can see them defined [here](https://github.com/inconshreveable/log15/blob/67afb5ed74ec82fd7ac8f49d27c509ac6f991970/logger.go#L28). Added support for those levels.